### PR TITLE
Add fast_jsonparser to gemspec and some cleanup

### DIFF
--- a/launchdarkly-server-sdk.gemspec
+++ b/launchdarkly-server-sdk.gemspec
@@ -37,7 +37,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.1"
   spec.add_runtime_dependency "ld-eventsource", "2.0.1"
 
-  spec.add_runtime_dependency "json", "~> 2.3"
   spec.add_runtime_dependency "fast_jsonparser", "~> 0.5"
   spec.add_runtime_dependency "http", ">= 4.4.0", "< 6.0.0"
 end

--- a/launchdarkly-server-sdk.gemspec
+++ b/launchdarkly-server-sdk.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5.0"
 
   spec.add_development_dependency "aws-sdk-dynamodb", "~> 1.57"
-  spec.add_development_dependency "bundler", "2.2.10"
   spec.add_development_dependency "rspec", "~> 3.10"
   spec.add_development_dependency "diplomat", "~> 2.4.2"
   spec.add_development_dependency "redis", "~> 4.2"

--- a/launchdarkly-server-sdk.gemspec
+++ b/launchdarkly-server-sdk.gemspec
@@ -38,5 +38,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "ld-eventsource", "2.0.1"
 
   spec.add_runtime_dependency "json", "~> 2.3"
+  spec.add_runtime_dependency "fast_jsonparser", "~> 0.5"
   spec.add_runtime_dependency "http", ">= 4.4.0", "< 6.0.0"
 end


### PR DESCRIPTION
Add the fast_jsonparser as a dependency since we're using it now in the lib.

No need to depend on json gem since it is packaged with Ruby. json 2.3 comes with Ruby 2.7. If we upgrade ruby in the future, this would actually cause us to have a legacy json parser. See: https://stdgems.org/json/